### PR TITLE
Update Omniva selector upon cart fragment changes, too

### DIFF
--- a/omniva-woocommerce/js/omniva.js
+++ b/omniva-woocommerce/js/omniva.js
@@ -9,7 +9,7 @@ jQuery('document').ready(function($){
     });
     $('input.shipping_method:checked').trigger('click');
  
-    $(document.body).on( 'updated_wc_div', function(){
+    $(document.body).on( 'updated_wc_div wc_fragments_refreshed', function(){
         if ($(".woocommerce-shipping-calculator").length) {
             $("select.shipping_method, :input[name^=shipping_method]:checked").trigger('change'); //TODO: Need better solution for dropdown update when in cart change country
         } else {
@@ -58,6 +58,12 @@ var omniva_addrese_change = false;
         var autoSelectTerminal = false;
         var searchTimeout = null;
         var select = $(this);
+        if (select.data('omniva_selector')) {
+            // Omniva selector is already applied.
+            return this;
+        } else {
+            select.data('omniva_selector', true);
+        }
         var not_found = omnivadata.not_found;
         var terminalIcon = null;
         var homeIcon = null;

--- a/omniva-woocommerce/js/omniva.js
+++ b/omniva-woocommerce/js/omniva.js
@@ -58,6 +58,10 @@ var omniva_addrese_change = false;
         var autoSelectTerminal = false;
         var searchTimeout = null;
         var select = $(this);
+        if (select.length < 1) {
+            // Do nothing if there is no element to apply the Omnivation to.
+            return this;
+        }
         if (select.data('omniva_selector')) {
             // Omniva selector is already applied.
             return this;


### PR DESCRIPTION
Update Omniva selector upon cart fragment changes, too. And ensure that multiple update triggering does not multiply Omniva selector instances (multiple drop-downs).

For example, we're using Porto theme that triggers `wc_fragments_refreshed` event (also emitted by WooCommerce originally) when it updates (replaces) parts of the cart page without trigerring `updated_wc_div`. Not sure which event is meant exactly for what, but it probably doesn't hurt to do an extra check and update if necessary.

In our (Porto) case, the Omniva selector gets updated all right if I click on the "Update cart" button. But if I use the "remove" icon on a specific product, the fragments get refreshed and the Omniva drop-down reappears as an unstyled "select" element (breaking the page layout) and does not get Omniva selector functionality applied.

If Omniva refresh happens on this other event as well, we also need Omnive selector to support calling it repeatedly on an already _omnived_ drop-down, otherwise duplicates start to appear.