### PR TITLE
Fix terminal loading after WooCommerce 11.1.0 update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.20.15]
+### Fixed
+- fixed parcel terminal loading on the block-based Checkout page after upgrading to WooCommerce 11.1.0
+
 ## [1.20.14]
 ### Added
 - added Picapac as a separate delivery method for Estonia

--- a/omniva-woocommerce/changelog.txt
+++ b/omniva-woocommerce/changelog.txt
@@ -1,5 +1,8 @@
 == Changelog ==
 
+= 1.20.15 =
+- fixed parcel terminal loading on the block-based Checkout page after upgrading to WooCommerce 11.1.0
+
 = 1.20.14 =
 - added Picapac as a separate delivery method for Estonia
 

--- a/omniva-woocommerce/core/class-core.php
+++ b/omniva-woocommerce/core/class-core.php
@@ -509,6 +509,10 @@ class OmnivaLt_Core
 
   private static function load_pre_init_hooks()
   {
+    // These endpoints are used by the Blocks frontend, but must not depend on
+    // the Blocks integration registry being initialized for the current page.
+    OmnivaLt_Wc_Blocks::register_ajax_actions();
+
     add_action('before_woocommerce_init', array('OmnivaLt_Compatibility', 'declare_wc_hpos_compatibility'));
     add_action('before_woocommerce_init', array('OmnivaLt_Compatibility', 'declare_wc_blocks_compatibility'));
     add_action('init', array('OmnivaLt_Core', 'textdomain'));

--- a/omniva-woocommerce/core/wc-blocks/class-blocks-integration.php
+++ b/omniva-woocommerce/core/wc-blocks/class-blocks-integration.php
@@ -271,6 +271,11 @@ class Omnivalt_Blocks_Integration implements IntegrationInterface
         // @phpstan-ignore-next-line
         $css_url = OMNIVALT_URL . 'assets/css/';
 
+        /**
+         * External assets may define only one of the supported file types.
+         *
+         * @var array<string, array{js?: string, css?: string}> $scripts
+         */
         $scripts = array(
             'omnivalt-library-mapping' => array(
                 'js' => 'terminal-mapping.js',
@@ -283,8 +288,12 @@ class Omnivalt_Blocks_Integration implements IntegrationInterface
         );
 
         foreach ( $scripts as $script_id => $script_files ) {
-            wp_enqueue_script($script_id, $js_url . $script_files['js'], array('jquery'), null, true);
-            wp_enqueue_style($script_id, $css_url . $script_files['css']);
+            if ( ! empty($script_files['js']) ) {
+                wp_enqueue_script($script_id, $js_url . $script_files['js'], array('jquery'), null, true);
+            }
+            if ( ! empty($script_files['css']) ) {
+                wp_enqueue_style($script_id, $css_url . $script_files['css']);
+            }
         }
     }
 

--- a/omniva-woocommerce/core/wc-blocks/class-blocks-integration.php
+++ b/omniva-woocommerce/core/wc-blocks/class-blocks-integration.php
@@ -252,77 +252,23 @@ class Omnivalt_Blocks_Integration implements IntegrationInterface
 
     public function register_additional_actions()
     {
-        add_action('wp_ajax_omnivalt_get_terminals', array($this, 'get_terminals_callback'));
-        add_action('wp_ajax_nopriv_omnivalt_get_terminals', array($this, 'get_terminals_callback'));
-        add_action('wp_ajax_omnivalt_get_dynamic_data', array($this, 'get_dynamic_data_callback'));
-        add_action('wp_ajax_nopriv_omnivalt_get_dynamic_data', array($this, 'get_dynamic_data_callback'));
+        OmnivaLt_Wc_Blocks::register_ajax_actions();
     }
 
     public function get_terminals_callback()
     {
-        if ( empty($_GET['country']) ) {
-            wp_send_json_error('Missing country parameter');
-            return;
-        }
-
-        $country = esc_attr($_GET['country']);
-        $type = (! empty($_GET['type'])) ? esc_attr($_GET['type']) : 'terminal';
-
-        $terminals = \OmnivaLt_Terminals::get_terminals_for_map_new($country, $type);
-        if ( empty($terminals) || ! is_array($terminals) ) {
-            $terminals = array();
-        }
-        
-        wp_send_json_success($terminals);
+        return OmnivaLt_Wc_Blocks::get_terminals_callback();
     }
 
     public function get_dynamic_data_callback()
     {
-        if ( empty($_GET['country']) ) {
-            wp_send_json_error('Missing country parameter');
-            return;
-        }
-        if ( empty($_GET['method']) ) {
-            wp_send_json_error('Missing method parameter');
-            return;
-        }
-
-        $country = esc_attr($_GET['country']);
-        $woo_method_id = esc_attr($_GET['method']);
-
-        $settings = \OmnivaLt_Core::get_settings();
-        $is_picapac = \OmnivaLt_Picapac::is_rate($woo_method_id);
-        $method_key = \OmnivaLt_Omniva_Order::get_method_key_from_id($woo_method_id);
-        $terminals_type = $is_picapac ? false : \OmnivaLt_Method::get_terminal_type($method_key);
-        $omniva_methods = \OmnivaLt_Method::get_all();
-        $omniva_method = ($terminals_type == 'post') ? $omniva_methods['post_specific'] : $omniva_methods['pickup'];
-
-        $provider = 'omniva';
-        $map_icon = $omniva_method['map_marker'];
-        if ( $country == 'FI' ) {
-            $provider = 'matkahuolto';
-            $map_icon = $omniva_method['display_by_country'][$country]['map_marker'];
-        }
-
-        $phone_regex = '';
-        if ( isset($settings['verify_phone']) && $settings['verify_phone'] === 'yes' ) {
-            $phone_regex_raw = \OmnivaLt_Helper::get_mobile_regex(strtoupper($country));
-            $phone_regex_clean = trim($phone_regex_raw, '/');
-            $phone_regex = json_decode(json_encode($phone_regex_clean));
-        }
-
-        wp_send_json_success(array(
-            'terminals_type' => $terminals_type,
-            'provider' => $provider,
-            'map_icon' => $map_icon,
-            'country' => $country,
-            'phone_regex' => $phone_regex
-        ));
+        return OmnivaLt_Wc_Blocks::get_dynamic_data_callback();
     }
 
     public function register_external_scripts()
     {
         $js_url = OMNIVALT_URL . 'assets/js/';
+        // @phpstan-ignore-next-line
         $css_url = OMNIVALT_URL . 'assets/css/';
 
         $scripts = array(
@@ -337,12 +283,8 @@ class Omnivalt_Blocks_Integration implements IntegrationInterface
         );
 
         foreach ( $scripts as $script_id => $script_files ) {
-            if ( ! empty($script_files['js']) ) {
-                wp_enqueue_script($script_id, $js_url . $script_files['js'], array('jquery'), null, true);
-            }
-            if ( ! empty($script_files['css']) ) {
-                wp_enqueue_style($script_id, $css_url . $script_files['css']);
-            }
+            wp_enqueue_script($script_id, $js_url . $script_files['js'], array('jquery'), null, true);
+            wp_enqueue_style($script_id, $css_url . $script_files['css']);
         }
     }
 

--- a/omniva-woocommerce/core/wc/class-wc-blocks.php
+++ b/omniva-woocommerce/core/wc/class-wc-blocks.php
@@ -1,6 +1,94 @@
 <?php
 class OmnivaLt_Wc_Blocks
 {
+    private static $ajax_actions_registered = false;
+
+    public static function register_ajax_actions()
+    {
+        if ( self::$ajax_actions_registered ) {
+            return;
+        }
+
+        self::$ajax_actions_registered = true;
+
+        add_action('wp_ajax_omnivalt_get_terminals', array(__CLASS__, 'get_terminals_callback'));
+        add_action('wp_ajax_nopriv_omnivalt_get_terminals', array(__CLASS__, 'get_terminals_callback'));
+        add_action('wp_ajax_omnivalt_get_dynamic_data', array(__CLASS__, 'get_dynamic_data_callback'));
+        add_action('wp_ajax_nopriv_omnivalt_get_dynamic_data', array(__CLASS__, 'get_dynamic_data_callback'));
+    }
+
+    public static function get_terminals_callback()
+    {
+        // This is a public, read-only endpoint used to load terminal data.
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No state is changed by this endpoint.
+        $country = isset($_GET['country']) ? strtoupper(sanitize_key(wp_unslash($_GET['country']))) : '';
+        if ( '' === $country ) {
+            wp_send_json_error('Missing country parameter');
+        }
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No state is changed by this endpoint.
+        $type = isset($_GET['type']) ? sanitize_key(wp_unslash($_GET['type'])) : 'terminal';
+
+        $terminals = OmnivaLt_Terminals::get_terminals_for_map_new($country, $type);
+        if ( empty($terminals) || ! is_array($terminals) ) {
+            $terminals = array();
+        }
+
+        wp_send_json_success($terminals);
+    }
+
+    public static function get_dynamic_data_callback()
+    {
+        // This is a public, read-only endpoint used to load checkout data.
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No state is changed by this endpoint.
+        $country = isset($_GET['country']) ? strtoupper(sanitize_key(wp_unslash($_GET['country']))) : '';
+        if ( '' === $country ) {
+            wp_send_json_error('Missing country parameter');
+        }
+
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- No state is changed by this endpoint.
+        $woo_method_id = isset($_GET['method']) ? sanitize_text_field(wp_unslash($_GET['method'])) : '';
+        if ( '' === $woo_method_id ) {
+            wp_send_json_error('Missing method parameter');
+        }
+
+        $settings = OmnivaLt_Core::get_settings();
+        $is_picapac = OmnivaLt_Picapac::is_rate($woo_method_id);
+        $method_key = OmnivaLt_Omniva_Order::get_method_key_from_id($woo_method_id);
+        $terminals_type = $is_picapac ? false : OmnivaLt_Method::get_terminal_type($method_key);
+        $omniva_methods = OmnivaLt_Method::get_all();
+        $omniva_method_key = ($terminals_type == 'post') ? 'post_specific' : 'pickup';
+
+        if ( empty($omniva_methods[$omniva_method_key]) || ! is_array($omniva_methods[$omniva_method_key]) ) {
+            wp_send_json_error('Invalid Omniva shipping method', 400);
+        }
+
+        $omniva_method = $omniva_methods[$omniva_method_key];
+        $provider = 'omniva';
+        $map_icon = isset($omniva_method['map_marker']) ? $omniva_method['map_marker'] : '';
+        if ( $country == 'FI' ) {
+            $provider = 'matkahuolto';
+            if ( isset($omniva_method['display_by_country'][$country]['map_marker']) ) {
+                $map_icon = $omniva_method['display_by_country'][$country]['map_marker'];
+            }
+        }
+
+        $phone_regex = '';
+        if ( isset($settings['verify_phone']) && $settings['verify_phone'] === 'yes' ) {
+            $phone_regex_raw = OmnivaLt_Helper::get_mobile_regex(strtoupper($country));
+            $phone_regex_clean = trim($phone_regex_raw, '/');
+            $phone_regex = $phone_regex_clean;
+        }
+
+        wp_send_json_success(array(
+            'terminals_type' => $terminals_type,
+            'provider' => $provider,
+            'map_icon' => $map_icon,
+            'country' => $country,
+            'phone_regex' => $phone_regex
+        ));
+    }
+
     public static function init()
     {
         require_once OmnivaLt_Core::get_core_dir() . 'wc-blocks/class-blocks-integration.php';


### PR DESCRIPTION
The AJAX actions were moved to OmnivaLt_Wc_Blocks and are now registered during the early plugin bootstrap, independently of WooCommerce Blocks registration.
The following endpoints remain unchanged:
- omnivalt_get_dynamic_data
- omnivalt_get_terminals
Both authenticated and unauthenticated AJAX requests are supported. A registration guard was also added to prevent duplicate hook registration. The existing Blocks integration methods now delegate to the centralized registration and callback methods.

Official WooCommerce reference: https://developer.woocommerce.com/2026/08/31/block-registration-skips-11-1/