### PR TITLE
Integrate GitHub Updates with WordPress

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.20.16]
+### Added
+- added native WordPress plugin update support
+- added WooCommerce dependency declaration to the plugin metadata
+
 ## [1.20.15]
 ### Fixed
 - fixed parcel terminal loading on the block-based Checkout page after upgrading to WooCommerce 11.1.0

--- a/omniva-woocommerce/changelog.txt
+++ b/omniva-woocommerce/changelog.txt
@@ -1,5 +1,9 @@
 == Changelog ==
 
+= 1.20.16 =
+- added native WordPress plugin update support
+- added WooCommerce dependency declaration to the plugin metadata
+
 = 1.20.15 =
 - fixed parcel terminal loading on the block-based Checkout page after upgrading to WooCommerce 11.1.0
 

--- a/omniva-woocommerce/core/class-core.php
+++ b/omniva-woocommerce/core/class-core.php
@@ -203,59 +203,6 @@ class OmnivaLt_Core
     return false;
   }
 
-  public static function check_update( $current_version = '' ) {
-    $update_params = self::get_configs('update');
-    
-    if (empty($update_params['check_url'])) {
-      return false;
-    }
-
-    $ch = curl_init(); 
-    curl_setopt($ch, CURLOPT_URL, $update_params['check_url']);
-    curl_setopt($ch, CURLOPT_USERAGENT,'Awesome-Octocat-App');
-    curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1); 
-    $response_data = json_decode(curl_exec($ch)); 
-    curl_close($ch);
-
-    if (isset($response_data->tag_name)) {
-      $update_info = array(
-        'version' => str_replace('v', '', $response_data->tag_name),
-        'url' => (isset($response_data->html_url)) ? $response_data->html_url : '#',
-      );
-      if (empty($current_version)) {
-        $plugin_data = get_file_data(self::$main_file_path, array('Version' => 'Version'), false);
-        $current_version = $plugin_data['Version'];
-      }
-      return (version_compare($current_version, $update_info['version'], '<')) ? $update_info : false;
-    }
-  
-    return false;
-  }
-
-  public static function update_message( $file, $plugin ) {
-    $check_update = self::check_update($plugin['Version']);
-    $update_params = self::get_configs('update');
-
-    if ( $check_update ) {
-      echo '<tr class="plugin-update-tr installer-plugin-update-tr js-otgs-plugin-tr active">';
-      echo '<td class="plugin-update" colspan="100%">';
-      echo '<div class="update-message notice inline notice-warning notice-alt">';
-      echo '<p>' . sprintf(__('A newer version of the plugin (%s) has been released.', 'omnivalt'), '<a href="' . $check_update['url'] . '" target="_blank">v' . $check_update['version'] . '</a>');
-      if ( ! empty($update_params['download_url']) ) {
-        echo ' ' . sprintf(__('You can download it by pressing %s.', 'omnivalt'), '<a href="' . $update_params['download_url'] . '">' . __('here', 'omnivalt') . '</a>');
-      }
-      if ( defined('OMNIVALT_CUSTOM_CHANGES') && ! empty(OMNIVALT_CUSTOM_CHANGES) ) {
-        echo '<br/><strong style="color:red;">' . __('We do not recommend update the plugin, because your plugin have changes that is not included in the update', 'omnivalt') . ':</strong>';
-        foreach ( OMNIVALT_CUSTOM_CHANGES as $change ) {
-          echo '<br/>· ' . $change . '';
-        }
-      }
-      echo '</p>';
-      echo '</div>';
-      echo '</td></tr>';
-    }
-  }
-
   public static function load_front_scripts()
   {
     $folder_css = '/assets/css/';
@@ -429,6 +376,7 @@ class OmnivaLt_Core
     require_once $core_dir . 'class-logger.php';
     require_once $core_dir . 'class-filters.php';
     require_once $core_dir . 'class-helper.php';
+    require_once $core_dir . 'class-updater.php';
     require_once $core_dir . 'wc/' . 'class-wc.php';
     require_once $core_dir . 'wc/' . 'class-wc-order.php';
     require_once $core_dir . 'wc/' . 'class-wc-product.php';
@@ -518,12 +466,16 @@ class OmnivaLt_Core
     add_action('init', array('OmnivaLt_Core', 'textdomain'));
     add_action('woocommerce_blocks_loaded', array('OmnivaLt_Wc_Blocks', 'init'));
     add_action('woocommerce_shipping_init', array('OmnivaLt_Core', 'init_shipping_method'));
+
+    add_filter('pre_set_site_transient_update_plugins', array('OmnivaLt_Updater', 'update_plugins'));
+    add_filter('site_transient_update_plugins', array('OmnivaLt_Updater', 'update_plugins'));
+    add_filter('plugins_api', array('OmnivaLt_Updater', 'plugin_information'), 10, 3);
   }
 
   private static function load_init_hooks()
   {
     add_action('admin_notices', array('OmnivaLt_Core', 'admin_notices'));
-    add_action('after_plugin_row_' . OMNIVALT_BASENAME, array('OmnivaLt_Core', 'update_message'), 10, 3);
+    add_action('in_plugin_update_message-' . OMNIVALT_BASENAME, array('OmnivaLt_Updater', 'update_message'), 10, 2);
 
     add_filter('plugin_action_links_' . OMNIVALT_BASENAME, array('OmnivaLt_Core', 'settings_link'));
   }

--- a/omniva-woocommerce/core/class-updater.php
+++ b/omniva-woocommerce/core/class-updater.php
@@ -1,0 +1,304 @@
+<?php
+defined('OMNIVALT_VERSION') or die();
+
+class OmnivaLt_Updater
+{
+  public static function get_latest_update()
+  {
+    $update_params = self::get_update_params();
+
+    if ( empty($update_params['check_url']) ) {
+      return false;
+    }
+
+    $cached_update = get_site_transient('omnivalt_latest_update');
+    if ( is_array($cached_update) ) {
+      if ( ! empty($cached_update['error']) ) {
+        return false;
+      }
+      if ( ! empty($cached_update['version']) && array_key_exists('tag', $cached_update) && array_key_exists('changelog', $cached_update) ) {
+        return $cached_update;
+      }
+    }
+
+    $response = wp_remote_get($update_params['check_url'], array(
+      'timeout' => 10,
+      'headers' => array(
+        'Accept' => 'application/vnd.github+json',
+        'User-Agent' => 'Omniva-WooCommerce/' . OMNIVALT_VERSION,
+      ),
+    ));
+
+    if ( is_wp_error($response) || 200 !== (int) wp_remote_retrieve_response_code($response) ) {
+      set_site_transient('omnivalt_latest_update', array('error' => true), HOUR_IN_SECONDS);
+      return false;
+    }
+
+    $response_data = json_decode(wp_remote_retrieve_body($response));
+    if ( ! is_object($response_data) || empty($response_data->tag_name) ) {
+      set_site_transient('omnivalt_latest_update', array('error' => true), HOUR_IN_SECONDS);
+      return false;
+    }
+
+    $release_tag = (string) $response_data->tag_name;
+    $release_notes = ( isset($response_data->body) && is_string($response_data->body) ) ? $response_data->body : '';
+    $release_notes = wpautop(wp_kses_post($release_notes));
+
+    $latest_update = array(
+      'tag' => $release_tag,
+      'version' => str_replace('v', '', $release_tag),
+      'url' => ( ! empty($response_data->html_url) ) ? esc_url_raw($response_data->html_url) : '#',
+      'package' => ( ! empty($update_params['download_url']) ) ? esc_url_raw($update_params['download_url']) : '',
+      'last_updated' => ( ! empty($response_data->published_at) ) ? sanitize_text_field($response_data->published_at) : '',
+      'changelog' => $release_notes,
+    );
+
+    set_site_transient('omnivalt_latest_update', $latest_update, 12 * HOUR_IN_SECONDS);
+
+    return $latest_update;
+  }
+
+  public static function check_update( $current_version = '' )
+  {
+    $update_info = self::get_latest_update();
+
+    if ( empty($update_info['version']) ) {
+      return false;
+    }
+
+    if ( empty($current_version) ) {
+      $plugin_data = get_file_data(OmnivaLt_Core::$main_file_path, array('Version' => 'Version'), '');
+      $current_version = $plugin_data['Version'];
+    }
+
+    return ( version_compare($current_version, $update_info['version'], '<') ) ? $update_info : false;
+  }
+
+  public static function update_plugins( $transient )
+  {
+    $plugin_basename = self::get_plugin_basename();
+
+    if ( '' === $plugin_basename || ! is_object($transient) || empty($transient->checked) || ! isset($transient->checked[$plugin_basename]) ) {
+      return $transient;
+    }
+
+    $update_info = self::check_update($transient->checked[$plugin_basename]);
+    if ( ! $update_info || empty($update_info['package']) ) {
+      return $transient;
+    }
+
+    $update_info = self::enrich_update_info_with_github_metadata($update_info);
+
+    $response = ( isset($transient->response) && is_array($transient->response) ) ? $transient->response : array();
+
+    $plugin_update = array(
+      'slug' => dirname($plugin_basename),
+      'plugin' => $plugin_basename,
+      'new_version' => $update_info['version'],
+      'url' => $update_info['url'],
+      'package' => $update_info['package'],
+    );
+
+    foreach ( array('requires', 'tested', 'requires_php') as $metadata_key ) {
+      if ( ! empty($update_info[$metadata_key]) ) {
+        $plugin_update[$metadata_key] = $update_info[$metadata_key];
+      }
+    }
+
+    $response[$plugin_basename] = (object) $plugin_update;
+    $transient_data = get_object_vars($transient);
+    $transient_data['response'] = $response;
+
+    return (object) $transient_data;
+  }
+
+  public static function plugin_information( $result, $action, $args )
+  {
+    $plugin_basename = self::get_plugin_basename();
+    $plugin_slug = dirname($plugin_basename);
+
+    if ( '' === $plugin_basename || 'plugin_information' !== $action || ! is_object($args) || empty($args->slug) || $plugin_slug !== $args->slug ) {
+      return $result;
+    }
+
+    $update_info = self::get_latest_update();
+    if ( ! $update_info ) {
+      return $result;
+    }
+
+    $update_info = self::enrich_update_info_with_github_metadata($update_info);
+    $requirements_section = '';
+
+    if ( ! empty($update_info['wc_requires']) ) {
+      $requirements_section .= '<p><strong>' . esc_html__('WC requires at least:', 'omnivalt') . '</strong> ' . esc_html($update_info['wc_requires']) . '</p>';
+    }
+    if ( ! empty($update_info['wc_tested']) ) {
+      $requirements_section .= '<p><strong>' . esc_html__('WC tested up to:', 'omnivalt') . '</strong> ' . esc_html($update_info['wc_tested']) . '</p>';
+    }
+
+    $sections = array(
+      'description' => __('Official Omniva shipping plugin for WooCommerce', 'omnivalt'),
+      'changelog' => ! empty($update_info['changelog']) ? $update_info['changelog'] : __('See the release notes on GitHub.', 'omnivalt'),
+    );
+    if ( '' !== $requirements_section ) {
+      $sections['requirements'] = $requirements_section;
+    }
+
+    $plugin_information = array(
+      'name' => 'Omniva shipping',
+      'slug' => $plugin_slug,
+      'version' => $update_info['version'],
+      'author' => 'Omniva',
+      'homepage' => 'https://www.omniva.lt/en/business/integrations-for-e-shops',
+      'download_link' => $update_info['package'],
+      'last_updated' => $update_info['last_updated'],
+      'sections' => $sections,
+    );
+
+    foreach ( array('requires', 'tested', 'requires_php') as $metadata_key ) {
+      if ( ! empty($update_info[$metadata_key]) ) {
+        $plugin_information[$metadata_key] = $update_info[$metadata_key];
+      }
+    }
+
+    return (object) $plugin_information;
+  }
+
+  public static function update_message( $plugin_data, $response )
+  {
+    if ( ! is_array($plugin_data) || ! is_object($response) ) {
+      return;
+    }
+
+    $update_params = self::get_update_params();
+    if ( ! empty($update_params['download_url']) ) {
+      echo '<br/><br/>' . sprintf(
+        esc_html__('Or you can manually download the plugin %s.', 'omnivalt'),
+        '<a href="' . esc_url($update_params['download_url']) . '" target="_blank" rel="noopener noreferrer">' . esc_html__('here', 'omnivalt') . '</a>'
+      );
+    }
+
+    $custom_changes = self::get_custom_changes();
+    if ( ! empty($custom_changes) ) {
+      echo '<br/><br/><strong style="color:red;">' . esc_html__('We do not recommend update the plugin, because your plugin have changes that is not included in the update', 'omnivalt') . ':</strong>';
+      foreach ( $custom_changes as $change ) {
+        if ( is_scalar($change) && '' !== (string) $change ) {
+          echo '<br/>&middot; ' . esc_html($change);
+        }
+      }
+    }
+  }
+
+  private static function enrich_update_info_with_github_metadata( $update_info )
+  {
+    if ( ! is_array($update_info) || isset($update_info['requires'], $update_info['tested'], $update_info['requires_php'], $update_info['wc_requires'], $update_info['wc_tested']) ) {
+      return $update_info;
+    }
+
+    $update_params = self::get_update_params();
+    $github_metadata = self::get_github_plugin_metadata(
+      isset($update_info['tag']) ? $update_info['tag'] : '',
+      isset($update_params['check_url']) ? $update_params['check_url'] : ''
+    );
+    $update_info = array_merge($update_info, $github_metadata);
+    set_site_transient('omnivalt_latest_update', $update_info, 12 * HOUR_IN_SECONDS);
+
+    return $update_info;
+  }
+
+  private static function get_github_plugin_metadata( $tag_name, $check_url )
+  {
+    $metadata = array(
+      'requires' => '',
+      'tested' => '',
+      'requires_php' => '',
+      'wc_requires' => '',
+      'wc_tested' => '',
+    );
+
+    if ( ! is_string($tag_name) || '' === $tag_name || ! is_string($check_url) || '' === $check_url ) {
+      return $metadata;
+    }
+
+    $check_url_parts = wp_parse_url($check_url);
+    if ( ! is_array($check_url_parts) || empty($check_url_parts['host']) || 'api.github.com' !== strtolower($check_url_parts['host']) || empty($check_url_parts['path']) ) {
+      return $metadata;
+    }
+
+    if ( ! preg_match('#^/repos/([^/]+/[^/]+)/releases/latest$#', $check_url_parts['path'], $repository_match) ) {
+      return $metadata;
+    }
+
+    $metadata_url = 'https://raw.githubusercontent.com/' . $repository_match[1] . '/' . rawurlencode($tag_name) . '/' . ltrim(self::get_plugin_basename(), '/');
+    $response = wp_remote_get($metadata_url, array(
+      'timeout' => 10,
+      'headers' => array(
+        'Accept' => 'text/plain',
+        'User-Agent' => 'Omniva-WooCommerce/' . OMNIVALT_VERSION,
+      ),
+    ));
+
+    if ( is_wp_error($response) || 200 !== (int) wp_remote_retrieve_response_code($response) ) {
+      return $metadata;
+    }
+
+    $plugin_source = wp_remote_retrieve_body($response);
+    if ( ! is_string($plugin_source) || '' === $plugin_source ) {
+      return $metadata;
+    }
+
+    $plugin_source = substr($plugin_source, 0, 8192);
+    $header_names = array(
+      'requires' => 'Requires at least',
+      'tested' => 'Tested up to',
+      'requires_php' => 'Requires PHP',
+      'wc_requires' => 'WC requires at least',
+      'wc_tested' => 'WC tested up to',
+    );
+
+    foreach ( $header_names as $metadata_key => $header_name ) {
+      $header_pattern = '/^[ \t]*(?:\*[ \t]*)?' . preg_quote($header_name, '/') . '[ \t]*:[ \t]*(.+?)[ \t]*$/mi';
+      if ( preg_match($header_pattern, $plugin_source, $header_match) ) {
+        $metadata[$metadata_key] = sanitize_text_field($header_match[1]);
+      }
+    }
+
+    return $metadata;
+  }
+
+  private static function get_plugin_basename()
+  {
+    if ( ! defined('OMNIVALT_BASENAME') ) {
+      return '';
+    }
+
+    $plugin_basename = constant('OMNIVALT_BASENAME');
+    return is_string($plugin_basename) ? $plugin_basename : '';
+  }
+
+  private static function get_update_params()
+  {
+    // The configuration is immutable during a request; avoid rebuilding all
+    // shipping methods and API settings for each updater hook invocation.
+    static $update_params = null;
+
+    if ( null === $update_params ) {
+      $configured_params = OmnivaLt_Core::get_configs('update');
+      $update_params = is_array($configured_params) ? $configured_params : array();
+    }
+
+    return $update_params;
+  }
+
+  private static function get_custom_changes()
+  {
+    $constant_name = 'OMNIVALT_CUSTOM_CHANGES';
+    if ( ! defined($constant_name) ) {
+      return array();
+    }
+
+    $defined_constants = get_defined_constants(true);
+    $custom_changes = isset($defined_constants['user'][$constant_name]) ? $defined_constants['user'][$constant_name] : null;
+    return is_array($custom_changes) ? $custom_changes : array();
+  }
+}

--- a/omniva-woocommerce/omniva-woocommerce.php
+++ b/omniva-woocommerce/omniva-woocommerce.php
@@ -11,6 +11,7 @@
  * 
  * Requires at least: 5.1
  * Tested up to: 7.1
+ * Requires Plugins: woocommerce
  * WC requires at least: 6.0.0
  * WC tested up to: 11.1.0
  * Requires PHP: 7.2


### PR DESCRIPTION
- Added a dedicated OmnivaLt_Updater class for plugin update handling.
- Integrated GitHub releases with WordPress’s native plugin update system.
- Added update version checks, release notes, and compatibility information.
- Added caching for update data:
- - Successful checks: 12 hours
- - Failed checks: 1 hour
- Added secure HTTP requests with timeouts and escaped output.
- Manual download link is always shown as a fallback.
- Added Requires Plugins: woocommerce to the plugin header.
- Kept Core responsible only for loading the updater and registering its hooks.